### PR TITLE
bower.json had marked.js as the main script, but in reality it's angular-marked.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Hypercubed <hypercubed@gmail.com>"
   ],
   "description": "AngularJS Markdown using marked.",
-  "main": "marked.js",
+  "main": "angular-marked.js",
   "keywords": [
     "angularjs",
     "markdown",


### PR DESCRIPTION
Small issue, it breaks bower-install Grunt plugin, because it keeps trying to include bower_components/angular-marked/marked.js. This should solve it. 

Thanks! 
