### PR TITLE
fix bug with ng-include

### DIFF
--- a/angular-marked.js
+++ b/angular-marked.js
@@ -307,7 +307,9 @@
         }
 
         if (attrs.marked) {
-          scope.$watch('marked', set);
+          scope.$watch('marked', function (marked) {
+            if (marked) set(marked);
+          });
         }
 
       }


### PR DESCRIPTION
without this fix, the directive would convert the included content to markdown as intended
however, adding a watcher on scope.marked does initially execute it. in this situation, the `set`function gets executed another time with empty contents and replaces the previously rendered markdown.

so now the watcher only fires the set function if there is actually content in scope.marked