### PR TITLE
Fix directive example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ app.config(['markedProvider', function(markedProvider) {
 
 ```html
 <marked>
-  #Markdown directive
+  # Markdown directive
   *It works!*  
 </marked>
 ```


### PR DESCRIPTION
The directive example fails because a space is required after #.