### PR TITLE
Avoid automatic highlighting when markdown specifies language

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Example using [highlight.js Javascript syntax highlighter](http://highlightjs.or
 markedProvider.setOptions({
   gfm: true,
   tables: true,
-  highlight: function (code) {
-    return hljs.highlightAuto(code).value;
+  highlight: function (code, lang) {
+    if (lang) {
+      return hljs.highlight(lang, code, true).value;
+    } else {
+      return hljs.highlightAuto(code).value;
+    }
   }
 });
 ```


### PR DESCRIPTION
When Markdown blocks specifies language, using `highlightAuto` completely ignores which language is being specified, and attempts to auto-detect the language.  This typically results in invalid language being used in many cases I've seen.  At first I though it was a bug in angular-marked, then marked, then highlightjs, only to realize it's how I was using highlightjs in my code.  Hoping to save some time for the next guy trying to use `highlightAuto` and wondering why code blocks are being highlighted incorrectly.