### PR TITLE
Bump marked version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "angular-marked",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "AngularJS Markdown using marked.",
   "main": "lib/angular-marked.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "marked": "^0.3.3"
+    "marked": "^0.3.12"
   },
   "devDependencies": {
     "browserify": "^13.0.1",


### PR DESCRIPTION
The latest version of marked has a number of improvements, including some XSS vulnerability fixes. Would it be possible to update?